### PR TITLE
Add filter so that the cache name can be changed

### DIFF
--- a/php/class-fragment-cache.php
+++ b/php/class-fragment-cache.php
@@ -60,7 +60,7 @@ abstract class Fragment_Cache {
 		}
 
 		$salt   = maybe_serialize( $salt );
-		$output = tlc_transient( 'fragment-cache-' . $this->type . '-' . $name . $salt )
+		$output = tlc_transient( apply_filters( 'fc_cache_name', 'fragment-cache-' . $this->type . '-' . $name . $salt, $this->type, $name, $args, $salt ) )
 				->updates_with( array( $this, 'wrap_callback' ), array( $name, $args ) )
 				->expires_in( $this->timeout )
 				->get();


### PR DESCRIPTION
The reason for this change is that I am using Polylang and there are different widgets on the English page to the German page. Both use the same sidebar. This filter would allow me to hook into the filter and add the language to name so that only the widget for that specific language is shown.

Here is an code example

``` php
function prefix_fragment_cache_cache_name ( $cache_name, $type, $name, $args, $salt ) {

    if ( isset( $args['args'][1]['pll_lang'] ) ) {
        $pll_lang = '-' . $args['args'][1]['pll_lang'];
    } else {
        $pll_lang = '';
    }

    return 'fragment-cache-' . $type . '-' . $name . $pll_lang . $salt;
}
add_filter( 'fc_skip_cache', 'prefix_fragment_cache_cache_name ', 10, 5 );
```
